### PR TITLE
chore: migrate to renovate 36 template name

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "platformAutomerge": true,
   "pre-commit": {
     "enabled": true


### PR DESCRIPTION
This migrates the renovate config to the one for version 36.0.0 and later.
