### PR TITLE
chore: ignore pre-commit.ci commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "enabled": true
   },
   "reviewers": ["morremeyer", "ekeih"],
+  "gitIgnoredAuthors": ["66853113+pre-commit-ci[bot]@users.noreply.github.com"],
   "packageRules": [
     {
       "description": "Automatically upgrade some dependencies",


### PR DESCRIPTION
This ignores commits from pre-commit.ci on renovate PRs, unblocking them.
