### PR TITLE
fix: strip v prefix from external-dns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,11 @@
       "matchDatasources": ["github-tags"],
       "matchPackageNames": ["python/cpython"],
       "extractVersion": "^v(?<version>.*)$"
+    },
+    {
+      "description": "Strip v prefix from external-dns",
+      "matchPackageNames": ["kubernetes-sigs/external-dns"],
+      "extractVersion": "^v(?<version>.*)$"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
Strips the "v" prefix since it is not part of the needed version.
