### PR TITLE
test: exclude kps-crds

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -7,4 +7,4 @@ excluded-charts:
   - hcloud-ccm-networks
   - hcloud-csi-driver
   - mailtrain
-  - kube-prometheus-stack-crds # Follow https://github.com/helm/community/pull/312 to see when we could switch to SSA. 
+  - kube-prometheus-stack-crds # Follow https://github.com/helm/community/pull/312 to see when we could switch to SSA.

--- a/ct.yaml
+++ b/ct.yaml
@@ -7,3 +7,4 @@ excluded-charts:
   - hcloud-ccm-networks
   - hcloud-csi-driver
   - mailtrain
+  - kube-prometheus-stack-crds # Follow https://github.com/helm/community/pull/312 to see when we could switch to SSA. 


### PR DESCRIPTION
The release secret is too large now. helm does not support SSA yet.

Deactivating the test until it does.