### PR TITLE
chore: deprecate mailtrain chart

### DIFF
--- a/charts/mailtrain/Chart.yaml
+++ b/charts/mailtrain/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: mailtrain
 description: Runs mailtrain in your kubernetes cluster
 type: application
-version: 2.0.1
+version: 3.0.0
 maintainers:
   - name: morremeyer
+deprecated: true

--- a/charts/mailtrain/README.md
+++ b/charts/mailtrain/README.md
@@ -1,18 +1,13 @@
 # mailtrain
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-Runs mailtrain in your kubernetes cluster
+> **:exclamation: This Helm Chart is deprecated!**
 
-## Maintainers
+:exclamation: This Helm Chart is deprecated!**
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| morremeyer |  |  |
-
-## Upgrading
-
-See [the upgrading instructions](UPGRADING.md) for upgrades with breaking changes.
+This chart will no longer be updated.
+Old versions be still be available, but the source will be removed after 2023-12-31.
 
 ## Values
 

--- a/charts/mailtrain/README.md.gotmpl
+++ b/charts/mailtrain/README.md.gotmpl
@@ -1,15 +1,11 @@
 {{ template "chart.header" . }}
-{{ template "chart.deprecationWarning" . }}
 {{ template "chart.badgesSection" . }}
 
-{{ template "chart.description" . }}
-{{ template "chart.homepageLine" . }}
-{{ template "chart.maintainersSection" . }}
-{{ template "chart.sourcesSection" . }}
-{{ template "chart.requirementsSection" . }}
+{{ template "chart.deprecationWarning" . }}
 
-## Upgrading
+:exclamation: This Helm Chart is deprecated!**
 
-See [the upgrading instructions](UPGRADING.md) for upgrades with breaking changes.
+This chart will no longer be updated.
+Old versions be still be available, but the source will be removed after 2023-12-31.
 
 {{ template "chart.valuesSection" . }}


### PR DESCRIPTION
This chart is for mailtrain v1, which is EOL for a while.
