### PR TITLE
feat(cronjob): allow maps as ConfigMap values

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 3.1.6
+version: 3.2.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 3.1.6](https://img.shields.io/badge/Version-3.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 

--- a/charts/cronjob/ci/configmap-map-values.yaml
+++ b/charts/cronjob/ci/configmap-map-values.yaml
@@ -1,0 +1,8 @@
+configMap:
+  enabled: true
+  data:
+    test:
+      mapKey1: Hello
+      mapKey2:
+        subKey1: test
+        subKey2: This should still work

--- a/charts/cronjob/ci/configmap-string-values.yaml
+++ b/charts/cronjob/ci/configmap-string-values.yaml
@@ -1,0 +1,4 @@
+configMap:
+  enabled: true
+  data:
+    test: This is a string

--- a/charts/cronjob/templates/configmap.yaml
+++ b/charts/cronjob/templates/configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   {{- range $key, $value := .Values.configMap.data }}
   {{ $key }}: |
-    {{- $value | nindent 4 }}
+    {{- $value | toString | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This adds the possibility to use non-string values for ConfigMap keys.
