### PR TITLE
fix: configure volume when only configMap.mountFiles is set

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 7.3.1
+version: 7.3.2
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 7.3.1](https://img.shields.io/badge/Version-7.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 7.3.2](https://img.shields.io/badge/Version-7.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 

--- a/charts/generic/ci/configMap-values.yaml
+++ b/charts/generic/ci/configMap-values.yaml
@@ -1,0 +1,5 @@
+configMap:
+  enabled: true
+  mountFiles:
+    - subPath: file.conf
+      mountPath: /file.conf

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -174,7 +174,7 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.persistence.enabled .Values.additionalVolumes .Values.configMap.mountPath .Values.configMap.mountFile }}
+      {{- if or .Values.persistence.enabled .Values.additionalVolumes .Values.configMap.mountPath .Values.configMap.mountFiles }}
       volumes:
         {{- if .Values.persistence.enabled }}
         - name: data


### PR DESCRIPTION
This fixes a typo in the `if` surrounding the `volumes` block that prevents
the whole block from getting created if `.Values.configMap` does only use the
`data` and `mountFiles` parameters.
