### PR TITLE
ci: Revert "ci: more automerging"

### DIFF
--- a/.github/workflows/renovate-config-validator-skip.yml
+++ b/.github/workflows/renovate-config-validator-skip.yml
@@ -1,0 +1,12 @@
+name: Validate renovate config - Skip
+
+on:
+  pull_request:
+    paths-ignore:
+      - renovate.json
+
+jobs:
+  renovate-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "renovate.json not changed, skipping"

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -1,0 +1,15 @@
+name: Validate renovate config
+
+on:
+  pull_request:
+    paths:
+      - renovate.json
+
+jobs:
+  renovate-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Validate
+        uses: rinchsan/renovate-config-validator@1ea1e8514f6a33fdd71c40b0a5fa3512b9e7b936 # v0.0.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,3 @@ repos:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
-
-  # Explicitly not using the renovate upstream hook because for some reason installing it is
-  # excruciatingly slow (> 10 minutes in some cases)
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.1
-    hooks:
-      - id: check-renovate

--- a/renovate.json
+++ b/renovate.json
@@ -62,8 +62,7 @@
       "fileMatch": ["(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\s*version:\\s*\"?(?<currentValue>.*)\"?"
-      ],
-      "automerge": true
+      ]
     },
     {
       "description": "Upgrade go version in a GitHub workflow",
@@ -72,8 +71,7 @@
         "# renovate: go-version\\s*go-version:\\s*\"?(?<currentValue>.*)\"?"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "go",
-      "automerge": true
+      "depNameTemplate": "go"
     },
     {
       "description": "Upgrade helm chart version for generated charts lockstep with the upstream releases",
@@ -86,24 +84,21 @@
         "# renovate: datasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\sversion: (?<currentValue>.*)",
         "# renovate: datasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\sappVersion: (?<currentValue>.*)",
         "# renovate: datasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\s+export\\s+VERSION=\"(?<currentValue>.*)\""
-      ],
-      "automerge": true
+      ]
     },
     {
       "description": "Upgrade helm-docs version in a GitHub workflow",
       "fileMatch": ["(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\s*run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@(?<currentValue>.*)"
-      ],
-      "automerge": true
+      ]
     },
     {
       "description": "Upgrade python-version version",
       "fileMatch": ["(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$"],
       "matchStrings": ["python-version:\\s(?<currentValue>.*)"],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "python/cpython",
-      "automerge": true
+      "depNameTemplate": "python/cpython"
     }
   ]
 }


### PR DESCRIPTION
Reverts community-tooling/charts#117

The renovate config is invalid and the check doesn't seem to catch it because we don't run pre-commit in the CI yet. Reverting for now, so renovate works while we work on a fix.