### PR TITLE
feat: add topologySpreadConstraints

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 7.3.2
+version: 7.4.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 7.3.2](https://img.shields.io/badge/Version-7.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 7.4.0](https://img.shields.io/badge/Version-7.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 
@@ -169,3 +169,4 @@ additionalObjects:
 | startupProbe | string | `nil` | Configure a startup probe for the pod |
 | terminationGracePeriodSeconds | int | `30` | How long the pod may take to terminate before it is killed by the kubelet |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` | [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) |

--- a/charts/generic/ci/topologySpreadConstraints-values.yaml
+++ b/charts/generic/ci/topologySpreadConstraints-values.yaml
@@ -1,0 +1,8 @@
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/component: some-app
+        app.kubernetes.io/name: release-name

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -217,3 +217,6 @@ additionalObjects: []
 
 # -- Additional sidecar containers
 additionalContainers: []
+
+# -- [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+topologySpreadConstraints: []


### PR DESCRIPTION
This adds the ability to set `topologySpreadConstraints`.

See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for documentation.
