### PR TITLE
feat: enable suspend configuration for CronJob

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 3.2.2
+version: 3.3.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 3.2.2](https://img.shields.io/badge/Version-3.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -97,4 +97,5 @@ configMap:
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | successfulJobsHistoryLimit | string | `nil` | The number of successful finished jobs to retain. |
+| suspend | bool | `false` | if the job should be suspended |
 | tolerations | list | `[]` | List of tolerations for the pod |

--- a/charts/cronjob/ci/suspend-values.yaml
+++ b/charts/cronjob/ci/suspend-values.yaml
@@ -1,0 +1,1 @@
+suspend: true

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  suspend: {{ .Values.suspend }}
   {{- with .Values.successfulJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ . }}
   {{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -12,6 +12,9 @@ failedJobsHistoryLimit: ~
 # -- schedule for the cronjob.
 schedule: "17 3 * * *"
 
+# -- if the job should be suspended
+suspend: false
+
 # -- if the Job should restart when the command fails
 restartPolicy: OnFailure
 


### PR DESCRIPTION
This enables suspension to be configured for the `cronjob` chart.
