### PR TITLE
feat: enable specification of existing volume for CronJob

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 3.4.0
+version: 3.5.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -85,6 +85,7 @@ configMap:
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | nodeSelector object for the pod |
 | persistence.enabled | bool | `false` |  |
+| persistence.existingVolume | string | `""` | To use an existing PersistentVolume resource, set its name here |
 | persistence.mountPath | string | `"/data"` | Where the persistent volume is mounted |
 | persistence.storage | string | `"1Gi"` | the amount of space to require for the volume |
 | persistence.storageClassName | string | `nil` | Set a storageClassName, otherwise the default class is used. |

--- a/charts/cronjob/templates/pvc.yaml
+++ b/charts/cronjob/templates/pvc.yaml
@@ -14,4 +14,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.storage }}
+  {{- with .Values.persistence.existingVolume }}
+  volumeName: "{{ . }}"
+  {{- end }}
 {{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -93,6 +93,9 @@ persistence:
   # -- Set a storageClassName, otherwise the default class is used.
   storageClassName: ~
 
+  # -- To use an existing PersistentVolume resource, set its name here
+  existingVolume: ""
+
 # -- requests and limits for the container
 resources: {}
 


### PR DESCRIPTION
This allows to specify an existing PerstistentVolume to be used for the CronJob's PVC
