### PR TITLE
chore: exclude generic values from updates since the nginx is a placeholder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   },
   "reviewers": ["morremeyer", "ekeih"],
   "gitIgnoredAuthors": ["66853113+pre-commit-ci[bot]@users.noreply.github.com"],
+  "ignorePaths": ["charts/generic/values.yaml"],
   "packageRules": [
     {
       "description": "Automatically upgrade 'version' key dependencies in GitHub Actions",


### PR DESCRIPTION
Exclude generic chart values from renovate updates.

The nginx image there is mainly a placeholder, so we don't need to update it.
