### PR TITLE
fix: app.kubernetes.io/version label invalid for sha256 tags

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 7.5.4
+version: 7.5.5
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 7.5.4](https://img.shields.io/badge/Version-7.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 7.5.5](https://img.shields.io/badge/Version-7.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 

--- a/charts/generic/ci/default-values.yaml
+++ b/charts/generic/ci/default-values.yaml
@@ -1,3 +1,7 @@
 labels:
   # This is here to verify that we're correctly adding newlines everywhere
   some-private-label: some-interesting-value
+
+# Regression test for https://github.com/community-tooling/charts/issues/246
+image:
+  tag: 1.26.0@sha256:ba9587717b056e1993b051f71cea30ddd5caf09ae2087b1eeb11329f52468e49

--- a/charts/generic/ci/semver-values.yaml
+++ b/charts/generic/ci/semver-values.yaml
@@ -1,0 +1,3 @@
+# Regression test for https://github.com/community-tooling/charts/issues/246
+image:
+  tag: 1.26.0-perl

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Common labels
 {{- define "generic.labels" -}}
 helm.sh/chart: {{ include "generic.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | mustRegexFind "[a-zA-Z0-9-_.]+$" | trunc 63 }}
 {{ include "generic.selectorLabels" . }}
 {{- with .Values.labels }}
 {{ toYaml . }}


### PR DESCRIPTION
This fixes an issue where the app.kubernetes.io/version label contains invalid characters
if a sha256 hash is used.

These are specified as latest@sha256:6703475278611b5a8871769095cb1b5c624ab4d2d9d3874d81afdbe1cb4b8cce, but
@ and : are forbidden characters in labels, and the maximum value length is 63.

Therefore, we now extract only valid characters at the end of the tag for the app.kubernetes.io/version label.
This is fully compatible with existing versions and yields:

* The SHA256 hash for SHA256 tags
* The exact tag for semver tags
* Whatever is left over when looking for only alphanumeric characters and -_. from the end of the tag

Resolves #246.
