### PR TITLE
fix: quote version tag for {number}.{number} tags

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 7.5.5
+version: 7.5.6
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 7.5.5](https://img.shields.io/badge/Version-7.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 7.5.6](https://img.shields.io/badge/Version-7.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 

--- a/charts/generic/ci/floating-point-values.yaml
+++ b/charts/generic/ci/floating-point-values.yaml
@@ -1,0 +1,4 @@
+# Regression test for https://github.com/community-tooling/charts/issues/279
+# "{number}.{number}" is interpreted as a floating point number and therefore needs to be quoted
+image:
+  tag: 1.25

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Common labels
 {{- define "generic.labels" -}}
 helm.sh/chart: {{ include "generic.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/version: {{ .Values.image.tag | mustRegexFind "[a-zA-Z0-9-_.]+$" | trunc 63 }}
+app.kubernetes.io/version: {{ .Values.image.tag | toString | mustRegexFind "[a-zA-Z0-9-_.]+$" | trunc 63 | quote }}
 {{ include "generic.selectorLabels" . }}
 {{- with .Values.labels }}
 {{ toYaml . }}


### PR DESCRIPTION
This quotes the version tag so that `{number}.{number}` tags are not interpreted as floating point numbers, but strings.

Resolves #279.