### PR TITLE
feat: add envFrom to cronjob chart

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install CRDs
         if: steps.list-changed.outputs.changed == 'true'
-        run: ./ci/install-crds.sh
+        run: ./ci/setup.sh
 
       - name: Run chart-testing (install)
         run: ct install --config ct.yaml

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 3.5.1
+version: 3.6.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -24,6 +24,16 @@ You can set environment variables directly with:
 ```yaml
 env:
   ENV_VARIABLE_NAME: "value"
+```
+
+### envFrom
+
+This enables you to load a complete ConfigMap or Secret into the env.
+
+```yaml
+envFrom:
+  - configMapRef:
+      name: special-config
 ```
 
 ### envValueFrom
@@ -73,6 +83,7 @@ configMap:
 | configMap.mountFiles | list | `[]` | Mounting of individual keys in the ConfigMap as files |
 | configMap.mountPath | string | `""` | If specified, the ConfigMap is mounted as a directory at this path |
 | env | list | `[]` | Directly set environment variables |
+| envFrom | list | `[]` | Directly set envFrom config |
 | envValueFrom | object | `{}` | Set environment variables from configMaps or Secrets |
 | failedJobsHistoryLimit | string | `nil` | The number of failed finished jobs to retain. |
 | fullnameOverride | string | `""` |  |

--- a/charts/cronjob/README.md.gotmpl
+++ b/charts/cronjob/README.md.gotmpl
@@ -23,6 +23,16 @@ env:
   ENV_VARIABLE_NAME: "value"
 ```
 
+### envFrom
+
+This enables you to load a complete ConfigMap or Secret into the env.
+
+```yaml
+envFrom:
+  - configMapRef:
+      name: special-config
+```
+
 ### envValueFrom
 
 This enables a simplified syntax to set envirnoment variables from a ConfigMap or Secret:

--- a/charts/cronjob/ci/default-values.yaml
+++ b/charts/cronjob/ci/default-values.yaml
@@ -1,1 +1,5 @@
 concurrencyPolicy: Forbid
+
+envFrom:
+  - configMapRef:
+      name: test-config

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -54,6 +54,9 @@ spec:
               {{- with .Values.args }}
               args: {{ toYaml . | nindent 16 }}
               {{- end }}
+              {{- with .Values.envFrom }}
+              envFrom: {{ toYaml . | nindent 16 }}
+              {{- end }}
               {{- if or .Values.env .Values.envValueFrom }}
               env:
                 {{- range $key, $value := .Values.env }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -52,6 +52,9 @@ command: []
 # -- arguments to pass to the command or binary being run
 args: []
 
+# -- Directly set envFrom config
+envFrom: []
+
 # -- Directly set environment variables
 env: []
 

--- a/ci/install-crds.sh
+++ b/ci/install-crds.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Nothing to do yet…"

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Creating ConfigMap test-config"
+kubectl create configmap test-config


### PR DESCRIPTION
This adds `envFrom` configurability to the cronjob chart.
