### PR TITLE
feat: add support for defaultMode specification

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 3.8.0
+version: 3.9.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 3.8.0](https://img.shields.io/badge/Version-3.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -81,6 +81,7 @@ configMap:
 | command | list | `[]` | the command or binary to run |
 | concurrencyPolicy | string | `"Allow"` | The [concurrencyPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) for the CronJob |
 | configMap.data | object | `{}` | The data for the ConfigMap. Both keys and values need to be strings. |
+| configMap.defaultMode | string | `nil` | Set the `defaultMode` for the files in the directory. |
 | configMap.enabled | bool | `false` | If a ConfigMap with configurable values should be created |
 | configMap.mountFiles | list | `[]` | Mounting of individual keys in the ConfigMap as files |
 | configMap.mountPath | string | `""` | If specified, the ConfigMap is mounted as a directory at this path |

--- a/charts/cronjob/ci/configmap-string-values.yaml
+++ b/charts/cronjob/ci/configmap-string-values.yaml
@@ -2,3 +2,6 @@ configMap:
   enabled: true
   data:
     test: This is a string
+
+  mountPath: /data
+  defaultMode: "0555"

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -118,5 +118,8 @@ spec:
             - name: configmap
               configMap:
                 name: {{ include "cronjob.fullname" . }}
+                {{- with .Values.configMap.defaultMode }}
+                defaultMode: {{ . }}
+                {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -79,6 +79,9 @@ configMap:
   # -- If specified, the ConfigMap is mounted as a directory at this path
   mountPath: ""
 
+  # -- Set the `defaultMode` for the files in the directory.
+  defaultMode: null
+
   # -- Mounting of individual keys in the ConfigMap as files
   mountFiles: []
     # - subPath: "config.yml"


### PR DESCRIPTION
To deploy e.g. scripts, you need to set the defaultMode. This PR enables that.
