### PR TITLE
feat: Add podSecurityStandard setting to make hardening easy

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 7.7.0
+version: 8.0.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 7.7.0](https://img.shields.io/badge/Version-7.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 8.0.0](https://img.shields.io/badge/Version-8.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -99,6 +99,7 @@ additionalObjects:
 | affinity | object | `{}` | Additional affinity terms. **Do not** specify PodAntiAffinities with preferredDuringSchedulingIgnoredDuringExecution here, these go to `additionalPreferredPodAntiAffinity`. All `requiredDuringScheduling` affinities need to be defined here. |
 | annotations | object | `{}` |  |
 | args | string | `nil` |  |
+| automountServiceAccountToken | string | `nil` | Whether to mount a serviceaccount token in the pod. Defaults to true unless `serviceAccount.create=false`. |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
@@ -147,7 +148,8 @@ additionalObjects:
 | podDisruptionBudget.maxUnavailable | string | `""` | How many pods can be unvailable, maximum |
 | podDisruptionBudget.minAvailable | string | `"25%"` | How many pods need to be available, minimum |
 | podLabels | object | `{}` | labels to add to the Pods |
-| podSecurityContext | object | `{}` |  |
+| podSecurityContext | object | `{}` | Pod-level security settings. If podSecurityStandard is set, podSecurityContext overrides those defaults. |
+| podSecurityStandard | string | `nil` | Set to `restricted` to set secure defaults for podSecurityContext and securityContext. See https://kubernetes.io/docs/concepts/security/pod-security-standards/ |
 | ports[0].containerPort | int | `80` |  |
 | ports[0].name | string | `"http"` |  |
 | ports[0].protocol | string | `"TCP"` |  |
@@ -156,7 +158,7 @@ additionalObjects:
 | resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the pods |
 | restartPolicy | string | `"Always"` |  |
 | revisionHistoryLimit | string | `nil` | The number of old ReplicaSets to retain |
-| securityContext | object | `{}` |  |
+| securityContext | object | `{}` | Container-level security settings. If podSecurityStandard is set, securityContext overrides those defaults. |
 | service.annotations | object | `{}` |  |
 | service.ip | string | `nil` |  |
 | service.loadBalancerClass | string | `nil` |  |

--- a/charts/generic/UPGRADING.md
+++ b/charts/generic/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading
 
+## 7.7.0 to 8.0.0
+
+If you are using the default ServiceAccount (which is generally discouraged) you must explicitly set `automountServiceAccountToken: true` now to match the behavior from 7.7.0.
+
+You should consider creating a dedicated ServiceAccount for your Deployment which automatically sets `automountServiceAccountToken: true`.
+
 ## 6.1.0 to 7.0.0
 
 Version 7.0.0 breaks compatibility for Kubernetes versions < 1.23.

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -71,3 +71,27 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate the podSecurityContext based on the podSecurityStandard
+*/}}
+{{- define "generic.podSecurityContext" -}}
+{{- if eq .Values.podSecurityStandard "restricted" }}
+{{- $sc := dict "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault") "fsGroup" 1000 "fsGroupChangePolicy" "OnRootMismatch" -}}
+{{- mustMerge $sc .Values.podSecurityContext | toYaml }}
+{{- else }}
+{{- .Values.podSecurityContext | toYaml }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate the securityContext based on the podSecurityStandard
+*/}}
+{{- define "generic.securityContext" -}}
+{{- if eq .Values.podSecurityStandard "restricted" }}
+{{- $psc := dict "privileged" false "allowPrivilegeEscalation" false "capabilities" (dict "drop" (list "ALL")) -}}
+{{- mustMerge $psc .Values.securityContext | toYaml }}
+{{- else }}
+{{- .Values.securityContext | toYaml }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -40,10 +40,11 @@ spec:
       {{- end }}
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "generic.serviceAccountName" . }}
+      automountServiceAccountToken: {{ default "true" .Values.automountServiceAccountToken }}
+      {{- else }}
+      automountServiceAccountToken: {{ default "false" .Values.automountServiceAccountToken }}
       {{- end }}
-      {{- with .Values.podSecurityContext }}
-      securityContext: {{- toYaml . | nindent 8 }}
-      {{- end }}
+      securityContext: {{- include "generic.podSecurityContext" . | nindent 8 }}
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- end }}
@@ -66,9 +67,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- with .Values.securityContext }}
-          securityContext: {{- toYaml . | nindent 12 }}
-          {{- end }}
+          securityContext: {{- include "generic.securityContext" . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.command }}

--- a/charts/generic/tests/securitycontext_test.yaml
+++ b/charts/generic/tests/securitycontext_test.yaml
@@ -1,0 +1,50 @@
+suite: test securityContext and podSecurityContext
+templates:
+  - templates/deployment.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: "verifies that the default securityContexts are blank"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value: {}
+      - equal:
+          path: spec.template.spec.securityContext
+          value: {}
+
+  - it: "verifies that the securityContext values can be set normally"
+    set:
+      securityContext.readOnlyRootFilesystem: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: "verifies that setting podSecurityStandard=restricted sets defaults"
+    set:
+      podSecurityStandard: restricted
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: "verifies that securityContext overrides and merges with defaults set by podSecurityStandard=restricted"
+    set:
+      podSecurityStandard: restricted
+      securityContext.readOnlyRootFilesystem: true
+      securityContext.privileged: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: true

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -29,15 +29,23 @@ serviceAccount:
   # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   name: ""
 
+# -- Whether to mount a serviceaccount token in the pod. Defaults to true unless `serviceAccount.create=false`.
+automountServiceAccountToken:
+
 # -- annotations to set for the Pods
 podAnnotations: {}
 
 # -- labels to add to the Pods
 podLabels: {}
 
+# -- Pod-level security settings. If podSecurityStandard is set, podSecurityContext overrides those defaults.
 podSecurityContext: {}
 
+# -- Container-level security settings. If podSecurityStandard is set, securityContext overrides those defaults.
 securityContext: {}
+
+# -- Set to `restricted` to set secure defaults for podSecurityContext and securityContext. See https://kubernetes.io/docs/concepts/security/pod-security-standards/
+podSecurityStandard:
 
 # -- How long the pod may take to terminate before it is killed by the kubelet
 terminationGracePeriodSeconds: 30
@@ -84,14 +92,16 @@ configMap:
   mountPath: ""
 
   # -- Mounting of individual keys in the ConfigMap as files
-  mountFiles: []
+  mountFiles:
+    []
     # - subPath: "config.yml"
     #   mountPath: /app/config.yml
 
 persistence:
   enabled: false
   # -- Annotations to add to the PersistentVolumeClaim
-  annotations: {}
+  annotations:
+    {}
     # helm.sh/resource-policy: keep
   # -- Where the persistent volume is mounted
   mountPath: /data
@@ -125,7 +135,7 @@ service:
 
   # -- List of ports. If you override it, you will have to explicitly add the default again.
   ports:
-      # -- Target port on the pod.
+    # -- Target port on the pod.
     - targetPort: http
       # -- Protocol to use for the target port.
       protocol: TCP
@@ -152,10 +162,10 @@ ingress:
   additionalLabels: {}
 
   hosts:
-      # -- host name to listen to
+    # -- host name to listen to
     - host: chart-example.local
       paths:
-          # -- URL path
+        # -- URL path
         - path: /
           # -- Name of the target port on the service
           servicePortName: http
@@ -172,7 +182,7 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 serviceMonitors:
-    # -- If a ServiceMonitor should be deployed. Needs the CRD installed
+  # -- If a ServiceMonitor should be deployed. Needs the CRD installed
   - enabled: false
     # -- Name of the resource, defaults to the release name
     name: ""
@@ -229,7 +239,8 @@ hooks:
   enabled: false
 
   # -- Hooks to be deployed. The map key is used as part of the Job name. Check the values file for an example.
-  jobs: {}
+  jobs:
+    {}
     # pre-upgrade:
     #   annotations:
     #     helm.sh/hook: pre-install,pre-upgrade


### PR DESCRIPTION
Ref: https://anaconda.atlassian.net/browse/CORE-7479

This PR lets users of the `generic` chart set `podSecurityStandard: restricted` to automatically set defaults for `podSecurityContext` and `securityContext` which are compliant with the "restricted" [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/).

Users can override these defaults (to either increase or decrease security) by setting `securityContext` or `podSecurityContext` (the dicts are merged together).

Also added the `automountServiceAccountToken` value. It defaults to false when not creating a serviceaccount, which is a CIS recommendation to avoid mounting an unnecessary default serviceaccount token which may accidentally have permissions assigned to it.

For example, a fully hardened Deployment would only require these values:

```yaml
podSecurityStandard: restricted
serviceAccount:
  create: false  # Now also disables automountServiceAccountToken
securityContext:
  # This is set separately since it's not part of the "restricted" Pod Security Standard
  readOnlyRootFilesystem: true
```

**MINOR BREAKING CHANGE**

If anyone is using the `default` ServiceAccount (which is generally discouraged) you must explicitly set `automountServiceAccountToken: true` now to match the original behavior. But you should consider creating a dedicated ServiceAccount for your Deployment which automatically sets `automountServiceAccountToken: true`.

The addition of `podSecurityStandard` is not a breaking change.