### PR TITLE
ci: ignore commits by pre-commit bot user for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,10 @@
     "automerge": false
   },
   "reviewers": ["morremeyer", "ekeih"],
-  "gitIgnoredAuthors": ["66853113+pre-commit-ci[bot]@users.noreply.github.com"],
+  "gitIgnoredAuthors": [
+    "66853113+pre-commit-ci[bot]@users.noreply.github.com",
+    "community-tooling@maurice-meyer.de"
+  ],
   "packageRules": [
     {
       "description": "Automatically upgrade 'version' key dependencies in GitHub Actions",


### PR DESCRIPTION
With this change, the bot user maintained my @morremeyer is ignored for renovate PR updates.
