### PR TITLE
feat: Add podSecurityStandard setting to make hardening easy

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 3.11.0
+version: 4.0.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 3.11.0](https://img.shields.io/badge/Version-3.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -78,6 +78,7 @@ configMap:
 | apiAccess.roleRules | list | `[]` | Rules for the Role the the pods are bound to. Check [the documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) for more information |
 | apiAccess.rules | list | `[]` | DEPRECATED, use roleRules. Rules for the API access of the ServiceAccount used by the CronJob pods. Check [the documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) for more information |
 | args | list | `[]` | arguments to pass to the command or binary being run |
+| automountServiceAccountToken | string | `nil` | Whether to mount a serviceaccount token in the pod. Defaults to true unless `serviceAccount.create=false`. |
 | command | list | `[]` | the command or binary to run |
 | commonLabels | object | `{}` | extra labels applied to all resources |
 | concurrencyPolicy | string | `"Allow"` | The [concurrencyPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) for the CronJob |
@@ -106,11 +107,12 @@ configMap:
 | persistence.storage | string | `"1Gi"` | the amount of space to require for the volume |
 | persistence.storageClassName | string | `nil` | Set a storageClassName, otherwise the default class is used. |
 | podAnnotations | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
+| podSecurityContext | object | `{}` | Pod-level security settings. If podSecurityStandard is set, podSecurityContext overrides those defaults. |
+| podSecurityStandard | string | `nil` | Set to `restricted` to set secure defaults for podSecurityContext and securityContext. See https://kubernetes.io/docs/concepts/security/pod-security-standards/ |
 | resources | object | `{}` | requests and limits for the container |
 | restartPolicy | string | `"OnFailure"` | if the Job should restart when the command fails |
 | schedule | string | `"17 3 * * *"` | schedule for the cronjob. |
-| securityContext | object | `{}` |  |
+| securityContext | object | `{}` | Container-level security settings. If podSecurityStandard is set, securityContext overrides those defaults. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |

--- a/charts/cronjob/UPGRADING.md
+++ b/charts/cronjob/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading
 
+## 3.11.0 to 4.0.0
+
+If you are using the default ServiceAccount (which is generally discouraged) you must explicitly set `automountServiceAccountToken: true` now to match the behavior from 3.11.0.
+
+You should consider creating a dedicated ServiceAccount for your CronJob which automatically sets `automountServiceAccountToken: true`.
+
 ## 2.1.1 to 3.0.0
 
 With 3.0.0, we dropped support for Kubernetes versions < 1.21.0.

--- a/charts/cronjob/templates/_helpers.tpl
+++ b/charts/cronjob/templates/_helpers.tpl
@@ -63,3 +63,27 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate the podSecurityContext based on the podSecurityStandard
+*/}}
+{{- define "cronjob.podSecurityContext" -}}
+{{- if eq .Values.podSecurityStandard "restricted" }}
+{{- $sc := dict "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault") "fsGroup" 1000 "fsGroupChangePolicy" "OnRootMismatch" -}}
+{{- mustMerge $sc .Values.podSecurityContext | toYaml }}
+{{- else }}
+{{- .Values.podSecurityContext | toYaml }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate the securityContext based on the podSecurityStandard
+*/}}
+{{- define "cronjob.securityContext" -}}
+{{- if eq .Values.podSecurityStandard "restricted" }}
+{{- $psc := dict "privileged" false "allowPrivilegeEscalation" false "capabilities" (dict "drop" (list "ALL")) -}}
+{{- mustMerge $psc .Values.securityContext | toYaml }}
+{{- else }}
+{{- .Values.securityContext | toYaml }}
+{{- end }}
+{{- end }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -34,10 +34,13 @@ spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets: {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
           serviceAccountName: {{ include "cronjob.serviceAccountName" . }}
-          {{- with .Values.podSecurityContext }}
-          securityContext: {{- toYaml . | nindent 12 }}
+          automountServiceAccountToken: {{ default "true" .Values.automountServiceAccountToken }}
+          {{- else }}
+          automountServiceAccountToken: {{ default "false" .Values.automountServiceAccountToken }}
           {{- end }}
+          securityContext: {{- include "cronjob.podSecurityContext" . | nindent 12 }}
           {{- with .Values.initContainers }}
           initContainers: {{ toYaml . | nindent 12 }}
           {{- end }}
@@ -46,9 +49,7 @@ spec:
           {{- end }}
           containers:
             - name: {{ .Chart.Name }}
-              {{- with .Values.securityContext }}
-              securityContext: {{- toYaml . | nindent 16 }}
-              {{- end }}
+              securityContext: {{- include "cronjob.securityContext" . | nindent 16 }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- with .Values.command }}

--- a/charts/cronjob/tests/securitycontext_test.yaml
+++ b/charts/cronjob/tests/securitycontext_test.yaml
@@ -1,0 +1,50 @@
+suite: test securityContext and podSecurityContext
+templates:
+  - templates/cronjob.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: "verifies that the default securityContexts are blank"
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext
+          value: {}
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+          value: {}
+
+  - it: "verifies that the securityContext values can be set normally"
+    set:
+      securityContext.readOnlyRootFilesystem: true
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: "verifies that setting podSecurityStandard=restricted sets defaults"
+    set:
+      podSecurityStandard: restricted
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: "verifies that securityContext overrides and merges with defaults set by podSecurityStandard=restricted"
+    set:
+      podSecurityStandard: restricted
+      securityContext.readOnlyRootFilesystem: true
+      securityContext.privileged: true
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.privileged
+          value: true

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -40,11 +40,19 @@ serviceAccount:
   # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   name: ""
 
+# -- Whether to mount a serviceaccount token in the pod. Defaults to true unless `serviceAccount.create=false`.
+automountServiceAccountToken:
+
 podAnnotations: {}
 
+# -- Pod-level security settings. If podSecurityStandard is set, podSecurityContext overrides those defaults.
 podSecurityContext: {}
 
+# -- Container-level security settings. If podSecurityStandard is set, securityContext overrides those defaults.
 securityContext: {}
+
+# -- Set to `restricted` to set secure defaults for podSecurityContext and securityContext. See https://kubernetes.io/docs/concepts/security/pod-security-standards/
+podSecurityStandard:
 
 # -- the command or binary to run
 command: []


### PR DESCRIPTION
Same as #400 but for the cronjob chart (sorry I forgot they were separate charts!)