### PR TITLE
fix: allow job history limits to be set to zero in cronjob chart

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 4.0.0
+version: 4.0.1
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -90,7 +90,7 @@ configMap:
 | env | list | `[]` | Directly set environment variables |
 | envFrom | list | `[]` | Directly set envFrom config |
 | envValueFrom | object | `{}` | Set environment variables from configMaps or Secrets |
-| failedJobsHistoryLimit | string | `nil` | The number of failed finished jobs to retain. |
+| failedJobsHistoryLimit | int | `1` | The number of failed finished jobs to retain. https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits |
 | fullnameOverride | string | `""` |  |
 | hostAliases | list | `[]` | [Host Aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases) |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -116,6 +116,6 @@ configMap:
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
-| successfulJobsHistoryLimit | string | `nil` | The number of successful finished jobs to retain. |
+| successfulJobsHistoryLimit | int | `3` | The number of successful finished jobs to retain. https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits |
 | suspend | bool | `false` | if the job should be suspended |
 | tolerations | list | `[]` | List of tolerations for the pod |

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -13,12 +13,8 @@ metadata:
     {{- end }}
 spec:
   suspend: {{ .Values.suspend }}
-  {{- with .Values.successfulJobsHistoryLimit }}
-  successfulJobsHistoryLimit: {{ . }}
-  {{- end }}
-  {{- with .Values.failedJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ . }}
-  {{- end }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
   schedule: "{{ .Values.schedule }}"
   concurrencyPolicy: "{{ .Values.concurrencyPolicy }}"
   jobTemplate:

--- a/charts/cronjob/tests/history_test.yaml
+++ b/charts/cronjob/tests/history_test.yaml
@@ -1,0 +1,39 @@
+suite: test successfulJobsHistoryLimit and failedJobsHistoryLimit
+templates:
+  - templates/cronjob.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+  - it: "verifies that the default successfulJobsHistoryLimit and failedJobsHistoryLimitare blank"
+    asserts:
+      - equal:
+          path: spec.successfulJobsHistoryLimit
+          value: null
+      - equal:
+          path: spec.failedJobsHistoryLimit
+          value: null
+
+  - it: "verifies that the successfulJobsHistoryLimit and failedJobsHistoryLimit value can be set normally"
+    set:
+      successfulJobsHistoryLimit: 99
+      failedJobsHistoryLimit: 13
+    asserts:
+      - equal:
+          path: spec.successfulJobsHistoryLimit
+          value: 99
+      - equal:
+          path: spec.failedJobsHistoryLimit
+          value: 13
+
+  - it: "verifies that setting successfulJobsHistoryLimit and failedJobsHistoryLimit can be set to zero"
+    set:
+      successfulJobsHistoryLimit: 0
+      failedJobsHistoryLimit: 0
+    asserts:
+      - equal:
+          path: spec.successfulJobsHistoryLimit
+          value: 0
+      - equal:
+          path: spec.failedJobsHistoryLimit
+          value: 0

--- a/charts/cronjob/tests/history_test.yaml
+++ b/charts/cronjob/tests/history_test.yaml
@@ -5,14 +5,14 @@ release:
   name: test-release
   namespace: test-namespace
 tests:
-  - it: "verifies that the default successfulJobsHistoryLimit and failedJobsHistoryLimitare blank"
+  - it: "verifies that the default successfulJobsHistoryLimit and failedJobsHistoryLimitare are not blank"
     asserts:
       - equal:
           path: spec.successfulJobsHistoryLimit
-          value: null
+          value: 3
       - equal:
           path: spec.failedJobsHistoryLimit
-          value: null
+          value: 1
 
   - it: "verifies that the successfulJobsHistoryLimit and failedJobsHistoryLimit value can be set normally"
     set:

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -7,10 +7,12 @@ image:
 concurrencyPolicy: "Allow"
 
 # -- The number of successful finished jobs to retain.
-successfulJobsHistoryLimit: ~
+# https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits
+successfulJobsHistoryLimit: 3
 
 # -- The number of failed finished jobs to retain.
-failedJobsHistoryLimit: ~
+# https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits
+failedJobsHistoryLimit: 1
 
 # -- schedule for the cronjob.
 schedule: "17 3 * * *"


### PR DESCRIPTION
I want to set `successfulJobsHistoryLimit` and/or `failedJobsHistoryLimit` to zero but the current chart wouldn't let me.

This PR fixes that and also adds tests.