### PR TITLE
feat: inference operator installation

### DIFF
--- a/charts/inference-operator/.helmignore
+++ b/charts/inference-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/inference-operator/Chart.yaml
+++ b/charts/inference-operator/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: inference-operator
+description: A Helm chart for Kubernetes Inference Operator
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+maintainers:
+  - name: morremeyer
+  - name: ekeih

--- a/charts/inference-operator/README.md
+++ b/charts/inference-operator/README.md
@@ -1,0 +1,41 @@
+# inference-operator
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes Inference Operator
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| morremeyer |  |  |
+| ekeih |  |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| crds.create | bool | `true` |  |
+| inference_service_gateway | string | `"some-gateway-name"` |  |
+| inference_service_hostname | string | `"some-hostname"` |  |
+| kurator_r2_bucket | string | `"some-r2-bucket"` |  |
+| kurator_s3_bucket | string | `"some-s3-bucket"` |  |
+| livenessProbe.failureThreshold | int | `3` |  |
+| livenessProbe.httpGet.path | string | `"/healthz"` |  |
+| livenessProbe.httpGet.port | int | `8080` |  |
+| livenessProbe.initialDelaySeconds | int | `10` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| rbac.create | bool | `true` |  |
+| resources.limits.cpu | string | `"200m"` |  |
+| resources.limits.memory | string | `"1024Mi"` |  |
+| resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.memory | string | `"512Mi"` |  |
+| service.nodePort | int | `30036` |  |
+| service.port | int | `8000` |  |
+| service.targetPort | int | `8080` |  |
+| service.type | string | `"NodePort"` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `"inference-operator"` |  |
+

--- a/charts/inference-operator/templates/_helpers.tpl
+++ b/charts/inference-operator/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+{{- define "inference-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "inference-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "inference-operator.name" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "inference-operator.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "inference-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "inference-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "inference-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/inference-operator/templates/crd.yaml
+++ b/charts/inference-operator/templates/crd.yaml
@@ -1,0 +1,162 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inferenceendpoints.ai.anaconda.com
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: ai.anaconda.com
+  names:
+    kind: InferenceEndpoint
+    listKind: InferenceEndpointList
+    plural: inferenceendpoints
+    singular: inferenceendpoint
+    shortNames:
+      - ie
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                suffix:
+                  type: string
+                  description: "Unique prefix for all resources associated with the CRD."
+                model_id:
+                  type: string
+                  description: "The model ID (base/name) to load."
+                quant:
+                  type: string
+                  description: "The quantization method (for file loading)."
+                startup_time:
+                  type: string
+                  description: "Expected time for the endpoint to be healthy."
+                memory:
+                  type: string
+                  description: "The amount of memory to provide the endpoint."
+                cpu:
+                  type: string
+                  description: "The amount of CPU to provide the endpoint."
+                gpu:
+                  type: boolean
+                  description: "Whether to run the endpoint with GPU support."
+                image_uri:
+                  type: string
+                  description: "The Docker image URI for the model runtime."
+                min_replicas:
+                  type: integer
+                  description: "The minimum number of replicas in the pod."
+                max_replicas:
+                  type: integer
+                  description: "The maximum number of replicas in the pod."
+                cpu_target_utilization:
+                  type: integer
+                  description: "Autoscaling metric for CPU utilization."
+                scale_up_stabilization_window:
+                  type: string
+                  description: "Autoscaling window."
+                namespace:
+                  type: string
+                  description: "The namespace to manage resources in."
+                apikey:
+                  type: string
+                  description: "The API key for llama.cpp server."
+                kurator_s3_bucket:
+                  type: string
+                  description: "Primary model source bucket."
+                kurator_s2_bucket:
+                  type: string
+                  description: "Secondary model source bucket."
+                inference_service_gateway:
+                  type: string
+                  description: "The external gateway for configuring access."
+                inference_service_hostname:
+                  type: string
+                  description: "The public hostname for ourselves."
+                llama_arg_n_gpu_layers:
+                  type: integer
+                  description: "LLM-specific parameter for GPU layers."
+                kurator_cloudflare:
+                  type: object
+                  description: "Cloudflare credentials configuration."
+                  properties:
+                    account_id:
+                      type: string
+                      description: "Cloudflare account ID."
+                    client_id:
+                      type: string
+                      description: "Cloudflare client ID."
+                    client_secret:
+                      type: object
+                      description: "Reference to the Cloudflare client secret."
+                      properties:
+                        name:
+                          type: string
+                          description: "Name of the Kubernetes Secret containing the Cloudflare client secret."
+                        key:
+                          type: string
+                          description: "Key within the Secret for the Cloudflare client secret."
+                      required:
+                        - name
+                        - key
+                  required:
+                    - account_id
+                    - client_id
+                    - client_secret
+              required:
+                - suffix
+                - model_id
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              description: "Status information for the InferenceEndpoint"
+              properties:
+                message:
+                  type: string
+                  description: "Human readable message indicating details about current operator phase or error."
+                service:
+                  type: string
+                  description: "Name of the created Kubernetes Service"
+                deployment:
+                  type: string
+                  description: "Name of the created Kubernetes Deployment"
+                hpa:
+                  type: string
+                  description: "Name of the created HorizontalPodAutoscaler"
+                virtualservice:
+                  type: string
+                  description: "Name of the created Istio VirtualService"
+                phase:
+                  type: string
+                  description: "Current phase of the InferenceEndpoint (Pending, Running, Failed, etc)"
+                  enum: ["Pending", "Running", "Failed", "Terminating", "Terminated"]
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Status
+          type: string
+          jsonPath: .status.phase
+          description: "Current status of the endpoint"
+        - name: Message
+          type: string
+          jsonPath: .status.message
+          description: "Status message"
+        - name: Model ID
+          type: string
+          jsonPath: .spec.model_id
+          description: "Model identifier"
+        - name: GPU
+          type: boolean
+          jsonPath: .spec.gpu
+          description: "GPU usage status"
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+          description: "Time since creation"

--- a/charts/inference-operator/templates/rbac.yaml
+++ b/charts/inference-operator/templates/rbac.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.rbac.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-inference-operator
+  labels:
+    {{- include "inference-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["ai.anaconda.com"]  # Replace with your API group
+    resources: ["inferenceendpoints"]    # Replace with your resource type
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+
+  # For status updates
+  - apiGroups: ["ai.anaconda.com"]
+    resources: ["inferenceendpoints/status"]
+    verbs: ["get", "patch", "update"]
+
+  - apiGroups: [ "" ]
+    resources: [ "services" ]
+    verbs: [ "list", "watch" ]
+
+  - apiGroups: [ "apps" ]
+    resources: [ "deployments" ]
+    verbs: [ "list", "watch" ]
+
+  # Permissions for HorizontalPodAutoscalers
+  - apiGroups: [ "autoscaling", "autoscaling/v2" ]
+    resources: [ "horizontalpodautoscalers" ]
+    verbs: [ "list", "watch" ]
+
+  # Permissions for Istio VirtualServices
+  - apiGroups: [ "networking.istio.io" ]
+    resources: [ "virtualservices" ]
+    verbs: [ "list", "watch" ]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-inference-operator
+  labels:
+    {{- include "inference-operator.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "inference-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-inference-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-inference-operator
+  labels:
+      {{- include "inference-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+ # Permissions for HorizontalPodAutoscalers
+  - apiGroups: ["autoscaling", "autoscaling/v2"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+ # Permissions for Istio VirtualServices
+  - apiGroups: ["networking.istio.io"]
+    resources: ["virtualservices"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+ # Additional permissions for checking pod status
+  - apiGroups: [""]
+    resources: ["pods", "pods/status"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "create", "update", "patch" ]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-inference-operator
+  labels:
+    {{- include "inference-operator.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "inference-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-inference-operator
+---
+{{- end }}

--- a/charts/inference-operator/values.yaml
+++ b/charts/inference-operator/values.yaml
@@ -1,0 +1,40 @@
+---
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: 200m
+    memory: 1024Mi
+
+serviceAccount:
+  create: true
+  name: "inference-operator"
+
+rbac:
+  create: true
+
+crds:
+  create: true
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+service:
+  type: NodePort
+  port: 8000
+  targetPort: 8080
+  nodePort: 30036
+
+
+kurator_s3_bucket: some-s3-bucket
+kurator_r2_bucket: some-r2-bucket
+inference_service_gateway: some-gateway-name
+inference_service_hostname: some-hostname


### PR DESCRIPTION
Add inference operator Helm chart for managing InferenceEndpoint custom resources. 
This chart includes CRD and RBAC configurations for deploying and managing inference operator services in Kubernetes clusters.