### PR TITLE
feat: Adds `backoffLimit` to cronjob template

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 4.0.2
+version: 4.0.3
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -79,6 +79,7 @@ configMap:
 | apiAccess.rules | list | `[]` | DEPRECATED, use roleRules. Rules for the API access of the ServiceAccount used by the CronJob pods. Check [the documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) for more information |
 | args | list | `[]` | arguments to pass to the command or binary being run |
 | automountServiceAccountToken | string | `nil` | Whether to mount a serviceaccount token in the pod. Defaults to true unless `serviceAccount.create=false`. |
+| backoffLimit | int | `6` | how many times a job should be re-attempted when the command fails. |
 | command | list | `[]` | the command or binary to run |
 | commonLabels | object | `{}` | extra labels applied to all resources |
 | concurrencyPolicy | string | `"Allow"` | The [concurrencyPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) for the CronJob |

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.0.3](https://img.shields.io/badge/Version-4.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -27,6 +27,7 @@ spec:
           labels: {{- include "cronjob.selectorLabels" . | nindent 12 }}
         spec:
           restartPolicy: {{ .Values.restartPolicy }}
+          backoffLimit: {{ .Values.backoffLimit }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -23,6 +23,9 @@ suspend: false
 # -- if the Job should restart when the command fails
 restartPolicy: OnFailure
 
+# -- how many times a job should be re-attempted when the command fails.
+backoffLimit: 6
+
 # -- initContainers to use. Requires a list of valid container specs.
 initContainers: []
 


### PR DESCRIPTION
- Adds the `backoffLimit` option to the cronjob template
- Defaults to `6`, which is the default set by Kubernetes

This is my first time working on this project. As far as I could tell, this all the wiring that is needed, but please let me know if I missed something.