### PR TITLE
[FIX] - add separator to hooks.yaml for loop

### DIFF
--- a/charts/generic/templates/hooks.yaml
+++ b/charts/generic/templates/hooks.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.hooks.enabled }}
 {{- range $job, $config := .Values.hooks.jobs }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Currently, if we loop through and create multiple hooks, the template that's produced isn't separated (pic1). Adding a separator to fix that(pic2).

![image](https://github.com/user-attachments/assets/1d6ff874-e049-47b8-932c-25e3de96dd2e)

![image](https://github.com/user-attachments/assets/6abcf760-e325-4d27-bf7a-63b7dc979061)
 