### PR TITLE
fix: disable mounting of ConfigMap when it is disabled

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 8.1.2
+version: 8.1.3
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 8.1.2](https://img.shields.io/badge/Version-8.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 8.1.3](https://img.shields.io/badge/Version-8.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 

--- a/charts/generic/ci/configMap-disabled-values.yaml
+++ b/charts/generic/ci/configMap-disabled-values.yaml
@@ -1,0 +1,7 @@
+# This is a regression test for a bug where setting configMap.enabled = false did not remove the mounts,
+# leading to a pod trying to mount a ConfigMap that didn't exist
+configMap:
+  enabled: false
+  mountFiles:
+    - subPath: file.conf
+      mountPath: /file.conf

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -90,12 +90,13 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           {{- end }}
-          {{- if or .Values.persistence.enabled .Values.additionalVolumeMounts .Values.configMap.mountPath .Values.configMap.mountFiles }}
+          {{- if or .Values.persistence.enabled .Values.additionalVolumeMounts (and (or .Values.configMap.mountPath .Values.configMap.mountFiles) .Values.configMap.enabled) }}
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
             {{- end }}
+            {{- if .Values.configMap.enabled }}
             {{- with .Values.configMap.mountPath }}
             - name: configmap
               mountPath: {{ . }}
@@ -106,6 +107,7 @@ spec:
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: true
+            {{- end }}
             {{- end }}
           {{- with .Values.additionalVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -164,7 +166,7 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.persistence.enabled .Values.additionalVolumes .Values.configMap.mountPath .Values.configMap.mountFiles }}
+      {{- if or .Values.persistence.enabled .Values.additionalVolumes (and (or .Values.configMap.mountPath .Values.configMap.mountFiles) .Values.configMap.enabled) }}
       volumes:
         {{- if .Values.persistence.enabled }}
         - name: data


### PR DESCRIPTION
Fixes a bug where disabling the ConfigMap did indeed remove the ConfigMap, but not it being mounted in the Deployment.
