### PR TITLE
feat(generic): add ability to mount volumes in hook jobs

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 8.2.0
+version: 8.3.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 8.2.0](https://img.shields.io/badge/Version-8.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 8.3.0](https://img.shields.io/badge/Version-8.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 
@@ -105,6 +105,7 @@ additionalObjects:
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | command | string | `nil` |  |
+| configMap.annotations | object | `{}` | Annotations to add to the ConfigMap |
 | configMap.data | object | `{}` | The data for the ConfigMap. Both keys and values need to be strings. |
 | configMap.enabled | bool | `false` | If a ConfigMap with configurable values should be created |
 | configMap.mountFiles | list | `[]` | Mounting of individual keys in the ConfigMap as files |

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -22,7 +22,38 @@ This is especially useful for tasks like database migrations that should only ta
 
 Hooks get the same default labels and annotations as all other resources, however, you can add more annotations as you like - check the [values.yaml](values.yaml) file for a default hook example.
 
-The `image`, `command` and `args` for as well as the `resources` are configurable for every hook Job individually and follow the same configuration style as the Deployment.
+The `image`, `command`, `args`, and `resources` are configurable for every hook Job individually and follow the same configuration style as the Deployment.
+
+By default, hooks do not mount the same volumes, configmaps, or secrets as the Deployment. If you need to mount and of those, you can use `additionalVolumeMounts` and `additionalVolumes`. Here is an example of mounting the same configmap as the Deployment:
+
+```yaml
+configMap:
+  annotations:
+    # When using pre-install hooks, ensure the confimap is created before the Job or else it will deadlock.
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-1"
+hooks:
+  enabled: true
+  jobs:
+    job-name:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "0"
+      ...
+      additionalVolumeMounts:
+        - name: my-configmap
+          mountPath: /config/app.conf
+          subPath: app.conf
+          readOnly: true
+
+      additionalVolumes:
+        - name: my-configmap
+          configMap:
+            # This is the name format unless you set "fullnameOverride"
+            name: myreleasename-generic
+```
+
+An alternative is to use `additionalObjects` to create ConfigMaps, Secrets, or PersistenVolumeClaims, or just create the objects outside of this helm chart.
 
 ## Complex values
 

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -24,7 +24,7 @@ Hooks get the same default labels and annotations as all other resources, howeve
 
 The `image`, `command`, `args`, and `resources` are configurable for every hook Job individually and follow the same configuration style as the Deployment.
 
-By default, hooks do not mount the same volumes, configmaps, or secrets as the Deployment. If you need to mount and of those, you can use `additionalVolumeMounts` and `additionalVolumes`. Here is an example of mounting the same configmap as the Deployment:
+By default, hooks do not mount the same volumes, configmaps, or secrets as the Deployment. If you need to mount any of those, you can use `additionalVolumeMounts` and `additionalVolumes`. Here is an example of mounting the same configmap as the Deployment:
 
 ```yaml
 configMap:

--- a/charts/generic/README.md.gotmpl
+++ b/charts/generic/README.md.gotmpl
@@ -21,7 +21,7 @@ Hooks get the same default labels and annotations as all other resources, howeve
 
 The `image`, `command`, `args`, and `resources` are configurable for every hook Job individually and follow the same configuration style as the Deployment.
 
-By default, hooks do not mount the same volumes, configmaps, or secrets as the Deployment. If you need to mount and of those, you can use `additionalVolumeMounts` and `additionalVolumes`. Here is an example of mounting the same configmap as the Deployment:
+By default, hooks do not mount the same volumes, configmaps, or secrets as the Deployment. If you need to mount any of those, you can use `additionalVolumeMounts` and `additionalVolumes`. Here is an example of mounting the same configmap as the Deployment:
 
 ```yaml
 configMap:

--- a/charts/generic/README.md.gotmpl
+++ b/charts/generic/README.md.gotmpl
@@ -19,7 +19,38 @@ This is especially useful for tasks like database migrations that should only ta
 
 Hooks get the same default labels and annotations as all other resources, however, you can add more annotations as you like - check the [values.yaml](values.yaml) file for a default hook example.
 
-The `image`, `command` and `args` for as well as the `resources` are configurable for every hook Job individually and follow the same configuration style as the Deployment.
+The `image`, `command`, `args`, and `resources` are configurable for every hook Job individually and follow the same configuration style as the Deployment.
+
+By default, hooks do not mount the same volumes, configmaps, or secrets as the Deployment. If you need to mount and of those, you can use `additionalVolumeMounts` and `additionalVolumes`. Here is an example of mounting the same configmap as the Deployment:
+
+```yaml
+configMap:
+  annotations:
+    # When using pre-install hooks, ensure the confimap is created before the Job or else it will deadlock.
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-1"
+hooks:
+  enabled: true
+  jobs:
+    job-name:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "0"
+      ...
+      additionalVolumeMounts:
+        - name: my-configmap
+          mountPath: /config/app.conf
+          subPath: app.conf
+          readOnly: true
+
+      additionalVolumes:
+        - name: my-configmap
+          configMap:
+            # This is the name format unless you set "fullnameOverride"
+            name: myreleasename-generic
+```
+
+An alternative is to use `additionalObjects` to create ConfigMaps, Secrets, or PersistenVolumeClaims, or just create the objects outside of this helm chart.
 
 ## Complex values
 

--- a/charts/generic/ci/hooks-external-configmap-values.yaml
+++ b/charts/generic/ci/hooks-external-configmap-values.yaml
@@ -1,0 +1,42 @@
+# Technically people should use `configMap` to create ConfigMaps but this simulates mounting an externally-created ConfigMap.
+additionalObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: external-hook-config
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "-1"
+        helm.sh/hook-delete-policy: hook-succeeded
+    data:
+      app.conf: test
+
+hooks:
+  enabled: true
+  jobs:
+    pre-install:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "0"
+        helm.sh/hook-delete-policy: before-hook-creation
+
+      image:
+        repository: alpine
+        pullPolicy: IfNotPresent
+        tag: latest
+
+      command:
+        - cat
+      args:
+        - /config/app.conf
+
+      additionalVolumeMounts:
+        - name: configmap
+          mountPath: /config/app.conf
+          subPath: app.conf
+          readOnly: true
+
+      additionalVolumes:
+        - name: configmap
+          configMap:
+            name: external-hook-config

--- a/charts/generic/ci/hooks-volumes-values.yaml
+++ b/charts/generic/ci/hooks-volumes-values.yaml
@@ -1,0 +1,56 @@
+# ct install uses a random release name (e.g. generic-a1b2c3d4). Pin the ConfigMap name so the hook volume reference stays valid.
+fullnameOverride: hooks-volumes-test
+
+configMap:
+  enabled: true
+  data:
+    migration.sql: |
+      SELECT 1;
+
+additionalObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: hook-credentials
+      annotations:
+        helm.sh/hook: post-install
+        helm.sh/hook-weight: "-1"
+        helm.sh/hook-delete-policy: hook-succeeded
+    stringData:
+      token: test
+
+hooks:
+  enabled: true
+  jobs:
+    post-install:
+      annotations:
+        helm.sh/hook: post-install
+        helm.sh/hook-weight: "0"
+        helm.sh/hook-delete-policy: before-hook-creation
+
+      image:
+        repository: alpine
+        pullPolicy: IfNotPresent
+        tag: latest
+
+      command:
+        - cat
+      args:
+        - /migrations/migration.sql
+
+      additionalVolumeMounts:
+        - name: configmap
+          mountPath: /migrations/migration.sql
+          subPath: migration.sql
+          readOnly: true
+        - name: credentials
+          mountPath: /etc/credentials
+          readOnly: true
+
+      additionalVolumes:
+        - name: configmap
+          configMap:
+            name: hooks-volumes-test
+        - name: credentials
+          secret:
+            secretName: hook-credentials

--- a/charts/generic/ci/hooks-volumes-values.yaml
+++ b/charts/generic/ci/hooks-volumes-values.yaml
@@ -15,7 +15,6 @@ additionalObjects:
       annotations:
         helm.sh/hook: post-install
         helm.sh/hook-weight: "-1"
-        helm.sh/hook-delete-policy: hook-succeeded
     stringData:
       token: test
 
@@ -26,7 +25,6 @@ hooks:
       annotations:
         helm.sh/hook: post-install
         helm.sh/hook-weight: "0"
-        helm.sh/hook-delete-policy: before-hook-creation
 
       image:
         repository: alpine

--- a/charts/generic/templates/configmap.yaml
+++ b/charts/generic/templates/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "generic.fullname" . }}
   labels:
     {{- include "generic.labels" . | nindent 4 }}
+  {{- with .Values.configMap.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   {{- range $key, $value := .Values.configMap.data }}
   {{ $key }}: |

--- a/charts/generic/templates/hooks.yaml
+++ b/charts/generic/templates/hooks.yaml
@@ -48,8 +48,16 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           {{- end }}
+          {{- with $config.additionalVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $config.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with $config.additionalVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -85,6 +85,9 @@ configMap:
   # -- If a ConfigMap with configurable values should be created
   enabled: false
 
+  # -- Annotations to add to the ConfigMap
+  annotations: {}
+
   # -- The data for the ConfigMap. Both keys and values need to be strings.
   data: {}
 
@@ -293,3 +296,14 @@ hooks:
 
     #   # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the hook pod
     #   resources: {}
+
+    #   # -- Note that if using pre-install/pre-upgrade hooks, any referenced ConfigMaps, Secrets, or Volumes must also be annotated with "helm.sh/hook: pre-install" or "helm.sh/hook: pre-upgrade" or else they will not exist when the job runs.
+    #   additionalVolumeMounts:
+    #     - name: configmap
+    #       mountPath: /migrations/migration.sql
+    #       subPath: migration.sql
+    #       readOnly: true
+    #   additionalVolumes:
+    #     - name: configmap
+    #       configMap:
+    #         name: my-release-generic


### PR DESCRIPTION
We have a use-case for running a hook that mounts a few files (two configmaps, used to define rows to create in a database, wanting to avoid having to do a full redeploy of the app itself in order to change the files).

This PR adds the ability to mount configmaps/secrets/volumes/etc (even ones created external to the helm chart) in hooks.

Also added the ability to annotate the configmap. This is needed in case you are using a pre-install/pre-upgrade hook since you'd need the configmap to also be created during that phase, or else the job will deadlock.

### AI Use Disclosure

Initial skeleton was generated, then I spent a bunch of time on hand-edits and understanding the code. Tests were unmodified after generation.